### PR TITLE
暗号機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,5 @@ gem 'devise'
 
 gem 'carrierwave'
 gem 'mini_magick'
+
+gem 'romaji'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    romaji (0.2.4)
+      rake (>= 0.8.0)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
     ruby_parser (3.14.2)
@@ -225,6 +227,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
+  romaji
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/javascripts/encryption.js
+++ b/app/assets/javascripts/encryption.js
@@ -1,0 +1,62 @@
+$(function(){
+  // 暗号プロトコル配列
+  var input_encryption = [];
+  // 暗号プロトコル[e,n,c,r,y,p,t,i,o,n]
+
+  // --------------暗号送信---------------------
+  function buildHTML(todo) {
+    var html = `<li class="todo">
+                  <div class = "todo__created_at">${todo.created_at}</div>
+                  <div class = "todo__content">${todo.content}</div>
+                </li>`;
+    return html;
+  }
+
+  // ---------------暗号プロトコル-------------------
+  $(window).keyup(function(event) {
+    input_encryption.push(event.keyCode);
+    if ( input_encryption[ input_encryption.length - 1 ] != encryption_cmd[ input_encryption.length - 1 ] ){
+      input_encryption = [];
+    } else if (input_encryption.length == encryption_cmd.length){
+      if($("#modal-overlay")[0]) return false ;
+      $('.encryption').fadeIn("slow");
+      $('.modal-overlay').fadeIn("slow");
+      $('.encryption__btn__yes').click(function(e){
+        console.log("ok");
+        e.preventDefault();
+        var message = $('.encryption__form__text').val();
+        var key = $('.encryption__form__num').val();
+        $('.encryption').fadeOut("slow");
+        $('.modal-overlay').fadeOut("slow");
+        $.ajax({
+          type: 'POST',
+          url: '/todos.json',
+          data: {
+            encryption: {
+              content: todo,
+              key: key
+            }
+          },
+          dataType: 'json'
+        })
+        .done(function(data) {
+          var html = buildHTML(data);
+          $('.todos').append(html);
+          $('.encryption__form__text').val('');
+        })
+        .fail(function() {
+          alert('error');
+        });
+        input_encryption = [];
+      })
+      $('.encryption__btn__no').click(function(e){
+        e.preventDefault();
+        $('.encryption').fadeOut("slow");
+        $('.modal-overlay').fadeOut("slow");
+        $('.encryption__form__text').val('');
+        input_encryption = [];
+      })
+    }
+    })
+
+})

--- a/app/assets/javascripts/encryption.js
+++ b/app/assets/javascripts/encryption.js
@@ -2,61 +2,87 @@ $(function(){
   // 暗号プロトコル配列
   var input_encryption = [];
   // 暗号プロトコル[e,n,c,r,y,p,t,i,o,n]
+  // var encryption_cmd = [69,78,67,82,89,80,84,73,79,78];
+
+  // 開発用
+  var encryption_cmd = [69,78,67];
 
   // --------------暗号送信---------------------
-  function buildHTML(todo) {
-    var html = `<li class="todo">
-                  <div class = "todo__created_at">${todo.created_at}</div>
-                  <div class = "todo__content">${todo.content}</div>
-                </li>`;
-    return html;
+  function buildHTML(encryption) {
+    var encryption_html = `
+                          <div class="message__mine">
+                            <div class="message__mine__index">
+                              <div class="message__mine__index__name">
+                                ${encryption.user_name}
+                              </div>
+                              <div class="message__mine__index__date">
+                                ${encryption.created_at}
+                              </div>
+                            </div>
+                            <div class="message__mine__low">
+                              <p class="message__mine__text">
+                                ${encryption.content}
+                              </p>
+                            </div>
+                          </div>`;
+    return encryption_html;
   }
 
-  // ---------------暗号プロトコル-------------------
-  $(window).keyup(function(event) {
-    input_encryption.push(event.keyCode);
+  // 暗号コマンド
+  $(window).keyup(function(e) {
+    input_encryption.push(e.keyCode);
     if ( input_encryption[ input_encryption.length - 1 ] != encryption_cmd[ input_encryption.length - 1 ] ){
+      // コマンド失敗
       input_encryption = [];
     } else if (input_encryption.length == encryption_cmd.length){
+    // コマンド成功
       if($("#modal-overlay")[0]) return false ;
       $('.encryption').fadeIn("slow");
       $('.modal-overlay').fadeIn("slow");
-      $('.encryption__btn__yes').click(function(e){
-        console.log("ok");
+      // 実行ボタン
+      $('#encryption_form').on('submit', function(e){
         e.preventDefault();
-        var message = $('.encryption__form__text').val();
-        var key = $('.encryption__form__num').val();
+        var formData = new FormData(this);
+        var url = $('#encryption_form').attr('action');
         $('.encryption').fadeOut("slow");
         $('.modal-overlay').fadeOut("slow");
         $.ajax({
           type: 'POST',
-          url: '/todos.json',
-          data: {
-            encryption: {
-              content: todo,
-              key: key
-            }
-          },
-          dataType: 'json'
+          url: url,
+          data:formData,
+          dataType: 'json',
+          processData: false,
+          contentType: false
         })
         .done(function(data) {
-          var html = buildHTML(data);
-          $('.todos').append(html);
+          var encryption_html = buildHTML(data);
+          $('.messages').append(encryption_html); 
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
           $('.encryption__form__text').val('');
+          $('.encryption__form__key').val('');
         })
         .fail(function() {
           alert('error');
         });
         input_encryption = [];
       })
+      // 閉じる
       $('.encryption__btn__no').click(function(e){
         e.preventDefault();
         $('.encryption').fadeOut("slow");
         $('.modal-overlay').fadeOut("slow");
         $('.encryption__form__text').val('');
+        $('.encryption__form__key').val('');
+        input_encryption = [];
+      })
+      $('.modal-overlay').click(function(e){
+        e.preventDefault();
+        $('.encryption').fadeOut("slow");
+        $('.modal-overlay').fadeOut("slow");
+        $('.encryption__form__text').val('');
+        $('.encryption__form__key').val('');
         input_encryption = [];
       })
     }
-    })
-
+  })
 })

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,26 +10,40 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-    if @message.save
-      respond_to do |format|
-        format.html { redirect_to group_messages_path, notice: "メッセージを送信しました" }
-        format.json
-      end
-    else
-      @messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力してください。'
-      render :index
+    @message.encryption
+    @message.save
+    respond_to do |format|
+      format.html
+      format.json
     end
   end
-
+  
   private
-
+  
   def message_params
-    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+    params.require(:message).permit(:content, :image, :key).merge(user_id: current_user.id)
   end
-
+  
+  def encryption_params
+    params.require(:encryption).permit(:content,:key)
+  end
+  
+  def decryption_params
+    params.require(:decryption).permit(:content,:key)
+  end
+  
   def set_group
     @group = Group.find(params[:group_id])
   end
   
 end
+
+# respond_to do |format|
+#   format.html { redirect_to group_messages_path, notice: "メッセージを送信しました" }
+#   format.json
+# end
+# else
+#   @messages = @group.messages.includes(:user)
+#   flash.now[:alert] = 'メッセージを入力してください。'
+#   render :index
+# end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,8 +1,25 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :group
+  require "romaji"
+  require "romaji/core_ext/string"
 
   validates :content, presence: true, unless: :image?
 
   mount_uploader :image, ImageUploader
+
+  def encryption
+    if key.present?
+      chars = [*"a".."z", *"A".."Z", *"0".."9"]
+      romaji =  content.romaji
+      self.content = romaji.tr(chars.join, chars.rotate(-3).join)
+    end
+  end
+
+  def decryption
+    chars = [*"a".."z", *"A".."Z", *"0".."9"]
+    @content = content.tr(chars.join, chars.rotate(-key).join)
+    self.content = @content.kana
+  end
+
 end

--- a/app/views/messages/_modal.html.haml
+++ b/app/views/messages/_modal.html.haml
@@ -5,17 +5,15 @@
   .encryption__text
     テキストとキーを入力してください
     （キーは大切に保管してください）
-  = form_for [@group, @message] do |f|
+  = form_for [@group, @message], html:{id:'encryption_form',class:'encryption_form'} do |f|
     .encryption__form
     = f.text_field :content, class: 'encryption__form__text', placeholder: 'テキスト'
-    = f.text_field :content, class: 'encryption__form__key', placeholder: 'キー'
-  .encryption__btn
-    .encryption__btn__yes
-      =link_to "#", class:"modal-btn" do
-        実行する
-    .encryption__btn__no
-      =link_to "#", class:"modal-btn" do
-        閉じる
+    = f.text_field :key, class: 'encryption__form__key', placeholder: 'キー'
+    .encryption__btn
+      = f.submit '実行する', class: 'encryption__btn__yes'
+      .encryption__btn__no
+        =link_to "#", class:"modal-btn" do
+          閉じる
 
 -# 解読
 .decryption

--- a/db/migrate/20200326100215_add_key_messages.rb
+++ b/db/migrate/20200326100215_add_key_messages.rb
@@ -1,0 +1,5 @@
+class AddKeyMessages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :messages, :key, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200319050717) do
+ActiveRecord::Schema.define(version: 20200326100215) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20200319050717) do
     t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "key"
     t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
     t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end


### PR DESCRIPTION
#what
-グループメッセージ画面でコマンドencryptionを入力すると暗号作成modalが開く。
-暗号にしたいメッセージとキーを入力するとシーザー暗号を作成。キーの分だけずらす。
-対応しているのはかな、カナ、ローマ字のみ。漢字はできない。
-かな、カナは一度ローマ字に分解してからシーザー暗号化する。

#why
-画面を覗かれてもキーを知っている人しか解読できないようになっているため、セキュリティを高めることができる。